### PR TITLE
Fixes runtime error when rendering server-side.

### DIFF
--- a/src/Tabs.soy
+++ b/src/Tabs.soy
@@ -17,13 +17,14 @@
 
 				<li class="{$isDisabled ? 'disabled' : ''} {$isCurrentTab ? 'active' : ''}" data-index="{index($currentTab)}" {if not $isDisabled and not $isCurrentTab}data-onclick="onClickItem"{/if} role="presentation">
 					<a
-						{if not $isDisabled}href="#"{/if}
-						ref="tab-{index($currentTab)}"
-						role="tab"
 						aria-expanded="{$isCurrentTab ? 'true' : 'false'}"
 						data-toggle="tab"
 						data-unfocusable="{$isDisabled ? 'true' : 'false'}"
-						tabindex="{$isCurrentTab ? '0' : '-1'}">
+						{if not $isDisabled}href="#"{/if}
+						ref="tab-{index($currentTab)}"
+						role="tab"
+						tabindex="{$isCurrentTab ? '0' : '-1'}"
+					>
 						{$currentTab.label}
 					</a>
 				</li>

--- a/src/Tabs.soy
+++ b/src/Tabs.soy
@@ -2,13 +2,14 @@
 
 /**
  * This renders the main element.
- * @param tab
- * @param tabs
- * @param? disabled
- * @param? elementClasses
- * @param? type
  */
 {template .render}
+	{@param tab: int}
+	{@param tabs: list<?>}
+	{@param? disabled: bool}
+	{@param? elementClasses: string}
+	{@param? type: string}
+
 	{if length($tabs) > 0}
 		<ul class="nav {$type != 'none' ? 'nav-' + $type : ''} {$elementClasses ?: ''}" role="tablist">
 			{foreach $currentTab in $tabs}


### PR DESCRIPTION
Previously we had the conditional attribute like this:
```html
<a
  {if not $isDisabled}href="#"{/if}
  ref="tab-{index($currentTab)}"
  role="tab"
  aria-expanded="{$isCurrentTab ? 'true' : 'false'}"
  data-toggle="tab"
  data-unfocusable="{$isDisabled ? 'true' : 'false'}">
```
and it worked fine when rendering on the client in javascript-land. However it was causing an issue when rendering on the server:
```
Failed to compute an output context for raw text `href="#"` starting in context (Context HTML_TAG_NAME)
```
Moving it up to the same line as the opening of the tag, or moving it after another attribute, seems to fix it. @jbalsas Have you seen anything like this?

Thanks!